### PR TITLE
Add producePayloadAttestationData snapshot tests

### DIFF
--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-missing-slot.request
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-missing-slot.request
@@ -1,0 +1,2 @@
+GET /eth/v1/validator/payload_attestation_data HTTP/1.0
+

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-missing-slot.response
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-missing-slot.response
@@ -1,0 +1,9 @@
+HTTP/1.0 400 Bad Request
+content-type: application/json
+content-length: 67
+date: Thu, 01 Jan 1970 00:00:00 GMT
+
+{
+  "code": 400,
+  "message": "invalid query string: missing field `slot`"
+}

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-32.request
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-32.request
@@ -1,0 +1,2 @@
+GET /eth/v1/validator/payload_attestation_data?slot=32 HTTP/1.0
+

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-32.response
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-32.response
@@ -1,0 +1,9 @@
+HTTP/1.0 400 Bad Request
+content-type: application/json
+content-length: 43
+date: Thu, 01 Jan 1970 00:00:00 GMT
+
+{
+  "code": 400,
+  "message": "state is pre-Gloas"
+}

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-64.request
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-64.request
@@ -1,0 +1,2 @@
+GET /eth/v1/validator/payload_attestation_data?slot=64 HTTP/1.0
+

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-64.response
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-64.response
@@ -1,0 +1,15 @@
+HTTP/1.0 200 OK
+content-type: application/json
+eth-consensus-version: gloas
+content-length: 181
+date: Thu, 01 Jan 1970 00:00:00 GMT
+
+{
+  "data": {
+    "beacon_block_root": "0xa19576230f5d8204014d7c355054fe3cca39388e5fe927360ed66daeccecba7f",
+    "slot": "64",
+    "payload_present": false,
+    "blob_data_available": false
+  },
+  "version": "gloas"
+}

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-65.request
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-65.request
@@ -1,0 +1,2 @@
+GET /eth/v1/validator/payload_attestation_data?slot=65 HTTP/1.0
+

--- a/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-65.response
+++ b/minimal/rapid-upgrade/quick-start/all-phases-all-keys/standard-read-only/payload-attestation-data-slot-65.response
@@ -1,0 +1,4 @@
+HTTP/1.0 204 No Content
+eth-consensus-version: gloas
+date: Thu, 01 Jan 1970 00:00:00 GMT
+


### PR DESCRIPTION
## Summary
Adds snapshot tests for `GET /eth/v1/validator/payload_attestation_data?slot=` on the rapid-upgrade Gloas chain.

## Cases covered
- `slot=64` → 200 with `PayloadAttestationData`
- `slot=65` → 204 (no block at slot)
- `slot=32` → 400 (pre-Gloas)
- missing `?slot=` → 400

Companion PR: grandinetech/grandine#805